### PR TITLE
Bitmap Text - update to v1.1.1. fixes #13 

### DIFF
--- a/src/SelbaWard/BitmapText.cpp
+++ b/src/SelbaWard/BitmapText.cpp
@@ -35,31 +35,31 @@
 namespace selbaward
 {
 
-BitmapText::BitmapText() :
-m_pBitmapFont(nullptr),
-m_vertices(sf::Quads),
-m_string(),
-m_color(sf::Color::White),
-m_tracking(1)
+BitmapText::BitmapText()
+	: m_pBitmapFont(nullptr)
+	, m_vertices(sf::Quads)
+	, m_string()
+	, m_color(sf::Color::White)
+	, m_tracking(1)
 {
 }
-
-/*
-void BitmapText::update()
-{
-	updateVertices();
-}
-*/
 
 void BitmapText::setBitmapFont(const BitmapFont& bitmapFont)
 {
 	m_pBitmapFont = &bitmapFont;
+	priv_updateVertices();
+}
+
+void BitmapText::setBitmapFont()
+{
+	m_pBitmapFont = nullptr;
+	priv_updateVertices();
 }
 
 void BitmapText::setString(const std::string& string)
 {
 	m_string = string;
-	updateVertices();
+	priv_updateVertices();
 }
 
 const std::string BitmapText::getString() const
@@ -70,7 +70,7 @@ const std::string BitmapText::getString() const
 void BitmapText::setTracking(int tracking)
 {
 	m_tracking = tracking;
-	updateVertices();
+	priv_updateVertices();
 }
 
 const int BitmapText::getTracking() const
@@ -81,7 +81,7 @@ const int BitmapText::getTracking() const
 void BitmapText::setColor(const sf::Color& color)
 {
 	m_color = color;
-	updateVertices();
+	priv_updateColor();
 }
 
 const sf::Color BitmapText::getColor() const
@@ -115,17 +115,27 @@ sf::FloatRect BitmapText::getLocalBounds() const
 }
 
 
+
 // PRIVATE
 
 void BitmapText::draw(sf::RenderTarget& target, sf::RenderStates states) const
 {
+	if (m_vertices.getVertexCount() == 0)
+		return;
+
 	states.transform *= getTransform();
 	states.texture = m_pBitmapFont->getTexture();
 	target.draw(m_vertices, states);
 }
 
-void BitmapText::updateVertices()
+void BitmapText::priv_updateVertices()
 {
+	if (m_pBitmapFont == nullptr)
+	{
+		m_vertices.clear();
+		m_bounds = { 0.f, 0.f, 0.f, 0.f };
+	}
+
 	m_vertices.resize(m_string.length() * 4);
 
 	sf::Vector2f penPosition{ 0.f, 0.f };
@@ -169,13 +179,18 @@ void BitmapText::updateVertices()
 		maxY = std::max(maxY, m_vertices[character * 4 + 2].position.y);
 	}
 
-	for (unsigned int v{ 0 }; v < m_vertices.getVertexCount(); ++v)
-		m_vertices[v].color = m_color;
+	priv_updateColor();
 
 	m_bounds.left = minX;
 	m_bounds.top = minY;
 	m_bounds.width = maxX - minX;
 	m_bounds.height = maxY - minY;
+}
+
+void BitmapText::priv_updateColor()
+{
+	for (unsigned int v{ 0 }; v < m_vertices.getVertexCount(); ++v)
+		m_vertices[v].color = m_color;
 }
 
 } // namespace selbaward

--- a/src/SelbaWard/BitmapText.hpp
+++ b/src/SelbaWard/BitmapText.hpp
@@ -40,13 +40,13 @@
 namespace selbaward
 {
 
-// SW Bitmap Text v1.1.0
+// SW Bitmap Text v1.1.1
 class BitmapText : public sf::Drawable, public sf::Transformable
 {
 public:
 	BitmapText();
-	//void update();
 	void setBitmapFont(const BitmapFont& bitmapFont);
+	void setBitmapFont();
 	void setString(const std::string& string = "");
 	const std::string getString() const;
 	void setTracking(int tracking);
@@ -68,7 +68,8 @@ private:
 	sf::FloatRect m_bounds;
 
 	virtual void draw(sf::RenderTarget& target, sf::RenderStates states) const;
-	void updateVertices();
+	void priv_updateVertices();
+	void priv_updateColor();
 };
 
 } // namespace selbaward


### PR DESCRIPTION
a null font is now considered a valid state and checks to see if it's
null. setBitmapFont is therefore now able to take no parameters to
nullify the font.
vertices are now updated when a font is set (including changed).
setting the color no longer requires an entire update for the vertices.
added "priv_" prefix to private methods as per convention.
reformatted the constructor's member initialisation as per convention.
if a font is null, updating the vertices simply clears the vertices and
resets the bounds to zero.
if no vertices exist (a null font is one case that can cause this), the
draw method is immediately exited with no code being executed.