### PR TITLE
Add rounded option to line

### DIFF
--- a/src/SelbaWard/Line.cpp
+++ b/src/SelbaWard/Line.cpp
@@ -209,6 +209,16 @@ sf::FloatRect Line::getTextureRect() const
 	return m_textureRect;
 }
 
+bool Line::getRounded() const
+{
+	return m_rounded;
+}
+
+void Line::setRounded(bool rounded)
+{
+	m_rounded = rounded;
+}
+
 
 
 // PRIVATE
@@ -222,6 +232,21 @@ void Line::draw(sf::RenderTarget& target, sf::RenderStates states) const
 		if (m_texture != nullptr)
 			states.texture = m_texture;
 		target.draw(m_quad, states);
+
+		if (m_rounded)
+		{
+			const float halfThickness{ m_thickness / 2.f };
+
+			sf::CircleShape circle{ halfThickness };
+			circle.setOrigin(halfThickness, halfThickness);
+			circle.setFillColor(getColor());
+
+			circle.setPosition(getPoint(0));
+			target.draw(circle, states);
+			
+			circle.setPosition(getPoint(1));
+			target.draw(circle, states);
+		}
 	}
 	else
 		target.draw(m_vertices, states);

--- a/src/SelbaWard/Line.cpp
+++ b/src/SelbaWard/Line.cpp
@@ -55,6 +55,7 @@ Line::Line()
 	//, m_color(sf::Color::White)
 	, m_texture(nullptr)
 	, m_textureRect()
+	, m_rounded(false)
 {
 }
 

--- a/src/SelbaWard/Line.hpp
+++ b/src/SelbaWard/Line.hpp
@@ -37,6 +37,7 @@
 
 #include <SFML/Graphics/VertexArray.hpp>
 #include <SFML/Graphics/Texture.hpp>
+#include <SFML/Graphics/CircleShape.hpp>
 
 namespace selbaward
 {
@@ -71,7 +72,8 @@ public:
 	const sf::Texture& getTexture() const;
 	void setTextureRect(const sf::FloatRect& textureRect);
 	sf::FloatRect getTextureRect() const;
-
+	bool getRounded() const;
+	void setRounded(bool rounded);
 
 
 
@@ -84,6 +86,7 @@ private:
 	float m_thickness; // 0 to draw as line, any value above thicknessEpsilon or below negative thicknessEpsilon to be drawn as a rectangle (using a quad) (currently using a rectangle shape instead)
 	const sf::Texture* m_texture;
 	sf::FloatRect m_textureRect;
+	bool m_rounded;
 
 	virtual void draw(sf::RenderTarget& target, sf::RenderStates states) const;
 	bool isThick() const;


### PR DESCRIPTION
`sw::Line` uses a rectangle for visualization, which doesn't look optimal when combining these lines at angles. I added the class `sw::RoundedLine` to add a circle at each end of the line to fix this problem.

It is not compatible with alpha colors, since the circle and quad overlap, but since this class will mostly be used for overlapping lines anyways, there is no need for that.

I hope I don't have any typos. Because there's no CMake, I couldn't verify on the fly.