### PR TITLE
Polygon-update to v1.2.3

### DIFF
--- a/src/SelbaWard/Polygon.cpp
+++ b/src/SelbaWard/Polygon.cpp
@@ -543,6 +543,9 @@ void Polygon::priv_triangulateEarClip()
 	// process
 	while (indices.size() > 3u)
 	{
+		if (ear.empty())
+			throw Exception("Polygon - ERROR: 0001");
+
 		std::size_t currentPoint{ ear.front() };
 		std::vector<std::size_t>::iterator currentIt{ std::find(indices.begin(), indices.end(), currentPoint) };
 		std::size_t current{ static_cast<std::size_t>(std::distance(indices.begin(), currentIt)) };

--- a/src/SelbaWard/Polygon.hpp
+++ b/src/SelbaWard/Polygon.hpp
@@ -39,7 +39,7 @@
 namespace selbaward
 {
 
-// SW Polygon v1.2.2
+// SW Polygon v1.2.3
 class Polygon : public sf::Drawable, public sf::Transformable
 {
 public:


### PR DESCRIPTION
now throws a Selba Ward exception showing an error code instead of attempting to access an empty vector (during the update method).

this allows both:
reporting an error for investigation and
catching the error suring runtime to avoid invalid use.

to catch this exception, simply put the update() method in a try block. remember to reset any changes before attempting to update again (e.g. if you've changed a vertex position before the update that failed, change the vertex position back to what it was before)