### PR TITLE
Add build script and CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI
+
+on: [push, pull_request, workflow_dispatch]
+
+concurrency:
+  group: environment-${{github.ref}}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: ${{matrix.platform.name}} ${{matrix.type.name}}
+    runs-on: ${{matrix.platform.os}}
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+        - { name: Windows MSVC,    os: windows-2022 }
+        - { name: Windows ClangCL, os: windows-2022, flags: -T ClangCL }
+        - { name: Windows Clang,   os: windows-2022, flags: -GNinja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ }
+        - { name: Windows MinGW,   os: windows-2022, flags: -GNinja -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ }
+        - { name: Linux GCC,       os: ubuntu-22.04, flags: -GNinja }
+        - { name: Linux Clang,     os: ubuntu-22.04, flags: -GNinja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ }
+        - { name: macOS,           os: macos-12,     flags: -GNinja }
+        type:
+        - { name: Release }
+        - { name: Debug }
+
+    steps:
+    - name: Install Linux Dependencies
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt update
+        sudo apt install ninja-build llvm xorg-dev libxrandr-dev libxcursor-dev libudev-dev libgl1-mesa-dev libegl1-mesa-dev
+
+    - name: Install macOS Tools
+      if: runner.os == 'macOS'
+      run: brew install ninja
+
+    - name: Checkout SFML
+      uses: actions/checkout@v3
+      with:
+        repository: SFML/SFML
+        path: sfml
+        ref: 2.6.0
+
+    - name: Configure SFML
+      run: |
+        cmake -S sfml -B sfml/build \
+          -DCMAKE_INSTALL_PREFIX=sfml/install \
+          -DCMAKE_BUILD_TYPE=${{matrix.type.name}} \
+          -DSFML_BUILD_AUDIO=OFF \
+          -DSFML_BUILD_NETWORK=OFF \
+          ${{matrix.platform.flags}}
+
+    - name: Build SFML
+      run: cmake --build sfml/build --config ${{matrix.type.name}} --target install
+
+    - name: Checkout SelbaWard
+      uses: actions/checkout@v3
+      with:
+        path: SelbaWard
+
+    - name: Configure SelbaWard
+      run: |
+        cmake -S SelbaWard -B SelbaWard/build \
+          -DBUILD_EXAMPLES=ON \
+          -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install \
+          -DCMAKE_BUILD_TYPE=${{matrix.type.name}} \
+          -DCMAKE_VERBOSE_MAKEFILE=ON \
+          -DSFML_ROOT=$GITHUB_WORKSPACE/sfml/install \
+          ${{matrix.platform.flags}}
+
+    - name: Build SelbaWard
+      run: cmake --build SelbaWard/build --config ${{matrix.type.name}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.16)
+project(SelbaWard LANGUAGES CXX)
+
+find_package(SFML 2.6 REQUIRED COMPONENTS graphics)
+
+add_library(SelbaWard
+    src/SelbaWard/BitmapFont.cpp
+    src/SelbaWard/BitmapText.cpp
+    src/SelbaWard/ConsoleScreen.cpp
+    src/SelbaWard/Crosshair.cpp
+    src/SelbaWard/ElasticSprite.cpp
+    src/SelbaWard/GallerySprite.cpp
+    src/SelbaWard/Line.cpp
+    src/SelbaWard/NinePatch.cpp
+    src/SelbaWard/PieChart.cpp
+    src/SelbaWard/PixelDisplay.cpp
+    src/SelbaWard/Polygon.cpp
+    src/SelbaWard/ProgressBar.cpp
+    src/SelbaWard/Ring.cpp
+    src/SelbaWard/SpinningCard.cpp
+    src/SelbaWard/Spline.cpp
+    src/SelbaWard/Sprite3d.cpp
+    src/SelbaWard/Starfield.cpp
+    src/SelbaWard/Starfield3d.cpp
+)
+add_library(SelbaWard::SelbaWard ALIAS SelbaWard)
+target_include_directories(SelbaWard PUBLIC src)
+target_link_libraries(SelbaWard PUBLIC sfml-graphics)
+target_compile_features(SelbaWard PUBLIC cxx_std_11)
+
+# Stop configuration if being consumed by a higher level project
+if(NOT PROJECT_IS_TOP_LEVEL)
+    return()
+endif()
+
+option(BUILD_EXAMPLES "Build examples" OFF)
+if(BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,26 @@
+add_executable(bitmap-text bitmapTextExample.cpp)
+target_link_libraries(bitmap-text PRIVATE SelbaWard::SelbaWard)
+
+add_executable(line lineExample.cpp)
+target_link_libraries(line PRIVATE SelbaWard::SelbaWard)
+
+add_executable(progress-bar progressBarExample.cpp)
+target_link_libraries(progress-bar PRIVATE SelbaWard::SelbaWard)
+
+add_executable(spinning-card spinningCardExample.cpp)
+target_link_libraries(spinning-card PRIVATE SelbaWard::SelbaWard)
+
+add_executable(spline splineExample.cpp)
+target_link_libraries(spline PRIVATE SelbaWard::SelbaWard)
+
+add_executable(spline2 splineExample2.cpp)
+target_link_libraries(spline2 PRIVATE SelbaWard::SelbaWard)
+
+add_executable(sprite3d sprite3dExample.cpp)
+target_link_libraries(sprite3d PRIVATE SelbaWard::SelbaWard)
+
+add_executable(sprite3d-card-fan sprite3dExampleCardFan.cpp)
+target_link_libraries(sprite3d-card-fan PRIVATE SelbaWard::SelbaWard)
+
+add_executable(sprite3d-spinning-card sprite3dExampleSpinningCard.cpp)
+target_link_libraries(sprite3d-spinning-card PRIVATE SelbaWard::SelbaWard)


### PR DESCRIPTION
This CMake script will be very useful to those who want to use SelbaWard in their own CMake project. It will make integration much simpler. It also provides a convenient way of building the entire library and all of its examples without having ot invoke the compiler many times over and over again.

Using this CMake script I was able to make a CI pipeline which automatically builds SelbaWard for Windows, Linux, and macOS. This will run every time anyone makes a PR or pushes to the repository. If it succeeds then we can be sure that the library still builds.

The CMake script can be expanded in the future to support more things but this PR represents the minimal starting point. It's nice and simple as-is.