### PR TITLE
add SpriteBatch v1.0.0

### DIFF
--- a/src/SelbaWard.hpp
+++ b/src/SelbaWard.hpp
@@ -46,6 +46,7 @@
 #include "SelbaWard/SpinningCard.hpp"
 #include "SelbaWard/Spline.hpp"
 #include "SelbaWard/Sprite3d.hpp"
+#include "SelbaWard/SpriteBatch.hpp"
 #include "SelbaWard/Starfield.hpp"
 #include "SelbaWard/Starfield3d.hpp"
 #include "SelbaWard/TileMap.hpp"

--- a/src/SelbaWard/SpriteBatch.cpp
+++ b/src/SelbaWard/SpriteBatch.cpp
@@ -1,0 +1,519 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// Selba Ward (https://github.com/Hapaxia/SelbaWard)
+// --
+//
+// Sprite Batch
+//
+// Copyright(c) 2023 M.J.Silk
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions :
+//
+// 1. The origin of this software must not be misrepresented; you must not
+// claim that you wrote the original software.If you use this software
+// in a product, an acknowledgment in the product documentation would be
+// appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such, and must not be
+// misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+// M.J.Silk
+// MJSilk2@gmail.com
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#include "SpriteBatch.hpp"
+
+#include <assert.h>
+
+namespace
+{
+
+const std::string exceptionPrefix{ "Sprite Batch: " };
+
+constexpr std::size_t numberOfVerticesPerQuad{ 6u };
+
+} // namespace
+
+namespace selbaward
+{
+
+SpriteBatch::SpriteBatch()
+	: m_texture{ nullptr }
+	, m_orderFunction{ nullptr }
+	, m_orderIndices()
+	, m_sprites()
+	, m_isGlobalUpdateRequired { false }
+	, m_vertices()
+{
+
+}
+
+void SpriteBatch::setTexture(const sf::Texture& texture)
+{
+	m_texture = &texture;
+}
+
+void SpriteBatch::setTexture()
+{
+	m_texture = nullptr;
+}
+
+void SpriteBatch::setNumberOfSprites(const std::size_t numberOfSprites)
+{
+	if (numberOfSprites == m_sprites.size())
+		return;
+
+	m_sprites.resize(numberOfSprites);
+	m_isGlobalUpdateRequired = true;
+}
+
+std::size_t SpriteBatch::getNumberOfSprites() const
+{
+	return m_sprites.size();
+}
+
+std::size_t SpriteBatch::insertSprite(std::size_t insertIndex, const std::size_t numberOfSprites, const sf::Sprite& sprite)
+{
+	if (numberOfSprites == 0u)
+		return m_sprites.size();
+
+	if (insertIndex > m_sprites.size())
+		insertIndex = m_sprites.size();
+	m_sprites.insert(m_sprites.begin() + insertIndex, numberOfSprites, Sprite{ false, sprite });
+	m_isGlobalUpdateRequired = true;
+	return m_sprites.size();
+}
+
+std::size_t SpriteBatch::addSprite(const std::size_t numberOfSprites, const sf::Sprite& sprite)
+{
+	return insertSprite(m_sprites.size(), numberOfSprites, sprite);
+}
+
+std::size_t SpriteBatch::removeSprite(const std::size_t removeIndex, const std::size_t numberOfSprites)
+{
+	if (numberOfSprites == 0u)
+		return m_sprites.size();
+
+	if (m_sprites.empty())
+		throw Exception(exceptionPrefix + "Cannot remove sprite; no sprites available.");
+
+	assert(removeIndex < m_sprites.size());
+	if (removeIndex >= m_sprites.size())
+		throw Exception(exceptionPrefix + "Cannot remove sprite; invalid sprite index.");
+
+	std::size_t endIndex{ removeIndex + numberOfSprites };
+	if (endIndex > m_sprites.size())
+		endIndex = m_sprites.size();
+	m_sprites.erase(m_sprites.begin() + removeIndex, m_sprites.begin() + endIndex);
+	m_isGlobalUpdateRequired = true;
+	return m_sprites.size();
+}
+
+std::size_t SpriteBatch::removeSprite(const std::size_t numberOfSprites)
+{
+	if (m_sprites.empty())
+		throw Exception(exceptionPrefix + "Cannot remove sprite; no sprites available.");
+
+	return removeSprite(m_sprites.size() - 1u, numberOfSprites);
+}
+
+void SpriteBatch::batchSprites(const std::vector<sf::Sprite>& sprites)
+{
+	const std::size_t numberOfSprites{ sprites.size() };
+	m_sprites.resize(numberOfSprites);
+	for (std::size_t i{ 0u }; i < numberOfSprites; ++i)
+		m_sprites[i] = { false, sprites[i] };
+	m_isGlobalUpdateRequired = true;
+}
+
+void SpriteBatch::batchSprites(const std::vector<sf::Sprite*>& sprites)
+{
+	const std::size_t numberOfSprites{ sprites.size() };
+	m_sprites.resize(numberOfSprites);
+	for (std::size_t i{ 0u }; i < numberOfSprites; ++i)
+		m_sprites[i] = { false, *sprites[i] };
+	m_isGlobalUpdateRequired = true;
+}
+
+void SpriteBatch::updateSprite(const std::size_t index, const sf::Sprite& sprite)
+{
+	priv_testIsIndexValid(index);
+
+	m_sprites[index].isUpdateRequired = true;
+	m_sprites[index].sprite = sprite;
+}
+
+sf::Sprite SpriteBatch::getSprite(const std::size_t index)
+{
+	priv_testIsIndexValid(index);
+	return m_sprites[index].sprite;
+}
+
+sf::Sprite SpriteBatch::operator[](const std::size_t index)
+{
+	priv_testIsIndexValid(index);
+	return m_sprites[index].sprite;
+}
+
+void SpriteBatch::setOrderFunction(const std::function<bool(const sf::Sprite* a, const sf::Sprite* b)>& orderFunction)
+{
+	m_orderFunction = orderFunction;
+	m_orderIndices.clear();
+}
+
+void SpriteBatch::setOrderFunction()
+{
+	m_orderFunction = nullptr;
+}
+
+void SpriteBatch::setOrder(const std::vector<std::size_t>& orderIndices)
+{
+	m_orderIndices = orderIndices;
+}
+
+void SpriteBatch::setOrder()
+{
+	m_orderIndices.clear();
+}
+
+void SpriteBatch::clearAllOrdering()
+{
+	setOrderFunction();
+	setOrder();
+}
+
+void SpriteBatch::setPosition(const std::size_t index, const sf::Vector2f position)
+{
+	priv_testIsIndexValid(index);
+	m_sprites[index].sprite.setPosition(position);
+	m_sprites[index].isUpdateRequired = true;
+}
+
+void SpriteBatch::setOrigin(const std::size_t index, const sf::Vector2f origin)
+{
+	priv_testIsIndexValid(index);
+	m_sprites[index].sprite.setOrigin(origin);
+	m_sprites[index].isUpdateRequired = true;
+}
+
+void SpriteBatch::setRotation(const std::size_t index, const float rotation)
+{
+	priv_testIsIndexValid(index);
+	m_sprites[index].sprite.setRotation(rotation);
+	m_sprites[index].isUpdateRequired = true;
+}
+
+void SpriteBatch::setScale(const std::size_t index, const sf::Vector2f scale)
+{
+	priv_testIsIndexValid(index);
+	m_sprites[index].sprite.setScale(scale);
+	m_sprites[index].isUpdateRequired = true;
+}
+
+void SpriteBatch::setScale(const std::size_t index, const float scale)
+{
+	setScale(index, { scale, scale });
+}
+
+void SpriteBatch::setTextureRect(const std::size_t index, const sf::IntRect textureRect)
+{
+	priv_testIsIndexValid(index);
+	m_sprites[index].sprite.setTextureRect(textureRect);
+	m_sprites[index].isUpdateRequired = true;
+}
+
+void SpriteBatch::setColor(const std::size_t index, const sf::Color& color)
+{
+	priv_testIsIndexValid(index);
+	m_sprites[index].sprite.setColor(color);
+	m_sprites[index].isUpdateRequired = true;
+}
+
+void SpriteBatch::move(const std::size_t index, const sf::Vector2f offset)
+{
+	priv_testIsIndexValid(index);
+	m_sprites[index].sprite.move(offset);
+	m_sprites[index].isUpdateRequired = true;
+}
+
+void SpriteBatch::rotate(const std::size_t index, const float angle)
+{
+	priv_testIsIndexValid(index);
+	m_sprites[index].sprite.rotate(angle);
+	m_sprites[index].isUpdateRequired = true;
+}
+
+void SpriteBatch::scale(const std::size_t index, const sf::Vector2f factor)
+{
+	priv_testIsIndexValid(index);
+	m_sprites[index].sprite.scale(factor);
+	m_sprites[index].isUpdateRequired = true;
+}
+
+void SpriteBatch::scale(const std::size_t index, const float factor)
+{
+	scale(index, { factor, factor });
+}
+
+sf::Vector2f SpriteBatch::getPosition(const std::size_t index) const
+{
+	priv_testIsIndexValid(index);
+	return m_sprites[index].sprite.getPosition();
+}
+
+sf::Vector2f SpriteBatch::getOrigin(const std::size_t index) const
+{
+	priv_testIsIndexValid(index);
+	return m_sprites[index].sprite.getOrigin();
+}
+
+float SpriteBatch::getRotation(const std::size_t index) const
+{
+	priv_testIsIndexValid(index);
+	return m_sprites[index].sprite.getRotation();
+}
+
+sf::Vector2f SpriteBatch::getScale(const std::size_t index) const
+{
+	priv_testIsIndexValid(index);
+	return m_sprites[index].sprite.getScale();
+}
+
+sf::IntRect SpriteBatch::getTextureRect(const std::size_t index) const
+{
+	priv_testIsIndexValid(index);
+	return m_sprites[index].sprite.getTextureRect();
+}
+
+sf::Color SpriteBatch::getColor(const std::size_t index) const
+{
+	priv_testIsIndexValid(index);
+	return m_sprites[index].sprite.getColor();
+}
+
+sf::FloatRect SpriteBatch::getLocalBounds(const std::size_t index) const
+{
+	priv_testIsIndexValid(index);
+	return m_sprites[index].sprite.getLocalBounds();
+}
+
+sf::FloatRect SpriteBatch::getGlobalBounds(const std::size_t index) const
+{
+	priv_testIsIndexValid(index);
+	return m_sprites[index].sprite.getGlobalBounds();
+}
+
+sf::Transform SpriteBatch::getTransform(const std::size_t index) const
+{
+	priv_testIsIndexValid(index);
+	return m_sprites[index].sprite.getTransform();
+}
+
+sf::Transform SpriteBatch::getInverseTransform(const std::size_t index) const
+{
+	priv_testIsIndexValid(index);
+	return m_sprites[index].sprite.getInverseTransform();
+}
+
+void SpriteBatch::move(const sf::Vector2f offset)
+{
+	for (auto& sprite : m_sprites)
+		sprite.sprite.move(offset);
+	m_isGlobalUpdateRequired = true;
+}
+
+void SpriteBatch::rotate(const float angle)
+{
+	for (auto& sprite : m_sprites)
+		sprite.sprite.rotate(angle);
+	m_isGlobalUpdateRequired = true;
+}
+
+void SpriteBatch::scale(const sf::Vector2f factor)
+{
+	for (auto& sprite : m_sprites)
+		sprite.sprite.scale(factor);
+	m_isGlobalUpdateRequired = true;
+}
+
+void SpriteBatch::scale(const float factor)
+{
+	scale({ factor, factor });
+	m_isGlobalUpdateRequired = true;
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+// PRIVATE
+
+void SpriteBatch::draw(sf::RenderTarget& target, sf::RenderStates states) const
+{
+	if ((m_orderFunction != nullptr) || (m_isGlobalUpdateRequired) || (!m_orderIndices.empty()))
+		priv_updateAll();
+	else
+		priv_updateRequired();
+
+	states.texture = m_texture;
+	target.draw(m_vertices.data(), m_vertices.size(), sf::PrimitiveType::Triangles, states);
+}
+
+void SpriteBatch::priv_testIsIndexValid(const std::size_t index) const
+{
+	const std::size_t numberOfSprites{ m_sprites.size() };
+	assert(index < numberOfSprites);
+	if (index >= numberOfSprites)
+		throw Exception(exceptionPrefix + "Sprite index invalid.");
+}
+
+void SpriteBatch::priv_updateAll() const
+{
+	if (m_sprites.empty())
+	{
+		m_vertices.clear();
+		return;
+	}
+
+	const std::size_t numberOfSprites{ m_sprites.size() };
+	m_vertices.resize(numberOfSprites * numberOfVerticesPerQuad);
+
+	if (!m_orderIndices.empty())
+	{
+		// create a vector of orig(ordered) indices
+		std::vector<std::size_t> origIndices(numberOfSprites);
+		for (std::size_t i{ 0u }; i < numberOfSprites; ++i)
+			origIndices[i] = i;
+
+		// copy order indices in reverse
+		std::vector<std::size_t> orderIndices{ m_orderIndices };
+		std::sort(orderIndices.rbegin(), orderIndices.rend());
+
+		// remove all indices in order indices from orig(ordered) indices
+		for (auto& orderIndex : orderIndices)
+			origIndices.erase(origIndices.begin() + orderIndex);
+
+		// rebuild order indices (copy) to contain order indices followed by remaining orig(ordered) indices
+		orderIndices.resize(numberOfSprites);
+		const std::size_t sizeOfOrderIndices{ m_orderIndices.size() };
+		for (std::size_t i{ 0u }; i < numberOfSprites; ++i)
+		{
+			if (i < sizeOfOrderIndices)
+				orderIndices[i] = m_orderIndices[i];
+			else
+				orderIndices[i] = origIndices[i - sizeOfOrderIndices];
+		}
+
+		// update quads
+		for (std::size_t i{ 0u }; i < numberOfSprites; ++i)
+		{
+			priv_updateQuad(i, &(m_sprites[orderIndices[i]].sprite));
+			m_sprites[i].isUpdateRequired = false; // this "i" doesn't need to match as we're clearing the update for all anyway
+		}
+	}
+	else if (m_orderFunction != nullptr)
+	{
+		// create vector of pointers to sort
+		std::vector<sf::Sprite*> pointers(numberOfSprites);
+		for (std::size_t i{ 0u }; i < numberOfSprites; ++i)
+			pointers[i] = &(m_sprites[i].sprite);
+
+		// sort pointers using custom order function
+		std::sort(pointers.begin(), pointers.end(), m_orderFunction);
+
+		// update quads
+		for (std::size_t i{ 0u }; i < numberOfSprites; ++i)
+		{
+			priv_updateQuad(i, pointers[i]);
+			m_sprites[i].isUpdateRequired = false;
+		}
+	}
+	else
+	{
+		// update quads
+		for (std::size_t i{ 0u }; i < numberOfSprites; ++i)
+		{
+			priv_updateQuad(i, &(m_sprites[i].sprite));
+			m_sprites[i].isUpdateRequired = false;
+		}
+	}
+
+	m_isGlobalUpdateRequired = false;
+}
+
+void SpriteBatch::priv_updateRequired() const
+{
+	const std::size_t numberOfSprites{ m_sprites.size() };
+	for (std::size_t i{ 0u }; i < numberOfSprites; ++i)
+	{
+		if (m_sprites[i].isUpdateRequired)
+		{
+			priv_updateQuad(i, &(m_sprites[i].sprite));
+			m_sprites[i].isUpdateRequired = false;
+		}
+	}
+}
+
+void SpriteBatch::priv_updateQuad(const std::size_t quadIndex, const sf::Sprite* sprite) const
+{
+	const std::size_t startVertex{ quadIndex * numberOfVerticesPerQuad };
+
+	const sf::Transform transform{ sprite->getTransform() };
+	const sf::Color color{ sprite->getColor() };
+	const sf::IntRect rect{ sprite->getTextureRect() };
+
+	sf::Vector2f shapeTopLeft{ 0.f, 0.f };
+	sf::Vector2f shapeBottomRight(rect.getSize());
+	sf::Vector2f shapeTopRight{ shapeBottomRight.x, shapeTopLeft.y };
+	sf::Vector2f shapeBottomLeft{ shapeTopLeft.x, shapeBottomRight.y };
+	sf::Vector2f textureTopLeft(rect.getPosition());
+	sf::Vector2f textureBottomRight{ textureTopLeft + shapeBottomRight };
+	sf::Vector2f textureTopRight{ textureBottomRight.x, textureTopLeft.y };
+	sf::Vector2f textureBottomLeft{ textureTopLeft.x, textureBottomRight.y };
+
+
+	shapeTopLeft = transform.transformPoint(shapeTopLeft);
+	shapeBottomRight = transform.transformPoint(shapeBottomRight);
+	shapeTopRight = transform.transformPoint(shapeTopRight);
+	shapeBottomLeft = transform.transformPoint(shapeBottomLeft);
+
+	m_vertices[startVertex + 0u].position = shapeTopLeft;
+	m_vertices[startVertex + 0u].texCoords = textureTopLeft;
+	m_vertices[startVertex + 0u].color = color;
+	m_vertices[startVertex + 1u].position = shapeBottomLeft;
+	m_vertices[startVertex + 1u].texCoords = textureBottomLeft;
+	m_vertices[startVertex + 1u].color = color;
+	m_vertices[startVertex + 2u].position = shapeBottomRight;
+	m_vertices[startVertex + 2u].texCoords = textureBottomRight;
+	m_vertices[startVertex + 2u].color = color;
+	m_vertices[startVertex + 5u].position = shapeTopRight;
+	m_vertices[startVertex + 5u].texCoords = textureTopRight;
+	m_vertices[startVertex + 5u].color = color;
+
+	m_vertices[startVertex + 3u] = m_vertices[startVertex + 0u];
+	m_vertices[startVertex + 4u] = m_vertices[startVertex + 2u];
+}
+
+} // namespace selbaward

--- a/src/SelbaWard/SpriteBatch.hpp
+++ b/src/SelbaWard/SpriteBatch.hpp
@@ -1,0 +1,168 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// Selba Ward (https://github.com/Hapaxia/SelbaWard)
+// --
+//
+// Sprite Batch
+//
+// Copyright(c) 2023 M.J.Silk
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions :
+//
+// 1. The origin of this software must not be misrepresented; you must not
+// claim that you wrote the original software.If you use this software
+// in a product, an acknowledgment in the product documentation would be
+// appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such, and must not be
+// misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+// M.J.Silk
+// MJSilk2@gmail.com
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef SELBAWARD_SPRITEBATCH_HPP
+#define SELBAWARD_SPRITEBATCH_HPP
+
+#include "Common.hpp"
+
+#include <SFML/Graphics/Sprite.hpp>
+#include <SFML/Graphics/Texture.hpp>
+
+#include <functional>
+
+namespace selbaward
+{
+
+// Sprite Batch v1.0.0
+class SpriteBatch : public sf::Drawable
+{
+public:
+	SpriteBatch();
+
+	void setTexture(const sf::Texture& texture);
+	void setTexture();
+
+	void setNumberOfSprites(std::size_t numberOfSprites);
+	std::size_t getNumberOfSprites() const;
+
+	std::size_t insertSprite(std::size_t insertIndex, std::size_t numberOfSprites = 1u, const sf::Sprite& sprite = sf::Sprite());
+	std::size_t addSprite(std::size_t numberOfSprites = 1u, const sf::Sprite& sprite = sf::Sprite()); // to back
+
+	std::size_t removeSprite(std::size_t removeIndex, std::size_t numberOfSprites = 1u);
+	std::size_t removeSprite(std::size_t numberOfSprites = 1u); // from back
+
+	void batchSprites(const std::vector<sf::Sprite>& sprites); // copy entire vector of sprites into batch and prepares it for entire update
+	void batchSprites(const std::vector<sf::Sprite*>& sprites); // copy entire vector of sprites (from the pointers) into batch and prepares it for entire update
+
+	void updateSprite(std::size_t index, const sf::Sprite& sprite);
+	sf::Sprite getSprite(std::size_t index); // this sf::Sprite is a copy, not access to the internally stored one!
+	sf::Sprite operator[](std::size_t index); // this sf::Sprite is a copy, not access to the internally stored one!
+
+	void setOrderFunction(const std::function<bool(const sf::Sprite* a, const sf::Sprite* b)>& orderFunction); // sets order function and clears any manual order
+	void setOrderFunction(); // clears order function and but does not clear any manual order
+
+	void setOrder(const std::vector<std::size_t>& orderIndices); // sets manual order, which overrides order function (but doesn't clear the order function)
+	void setOrder(); // clears manual order and reinstates order function, if available
+
+	void clearAllOrdering(); // clears order function and also the manual order
+
+
+
+
+
+
+
+	// standard SFML sprite methods
+
+	// setters - absolute
+	void setPosition(std::size_t index, sf::Vector2f position);
+	void setOrigin(std::size_t index, sf::Vector2f origin);
+	void setRotation(std::size_t index, float rotation);
+	void setScale(std::size_t index, sf::Vector2f scale);
+	void setScale(std::size_t index, float scale); // sets both x and y to the scale
+	void setTextureRect(std::size_t index, sf::IntRect textureRect);
+	void setColor(std::size_t index, const sf::Color& color);
+
+	// setters - relative
+	void move(std::size_t index, sf::Vector2f offset);
+	void rotate(std::size_t index, float angle);
+	void scale(std::size_t index, sf::Vector2f factor);
+	void scale(std::size_t index, float factor); // scales both x and y by the same factor
+
+	// getters (that match the setters)
+	sf::Vector2f getPosition(std::size_t index) const;
+	sf::Vector2f getOrigin(std::size_t index) const;
+	float getRotation(std::size_t index) const;
+	sf::Vector2f getScale(std::size_t index) const;
+	sf::IntRect getTextureRect(std::size_t index) const;
+	sf::Color getColor(std::size_t index) const;
+	
+	// getters (extra - no matching setter)
+	sf::FloatRect getLocalBounds(std::size_t index) const;
+	sf::FloatRect getGlobalBounds(std::size_t index) const;
+	sf::Transform getTransform(std::size_t index) const;
+	sf::Transform getInverseTransform(std::size_t index) const;
+
+
+
+	// global sprite methods (affects all sprites) - relative
+	void move(sf::Vector2f offset);
+	void rotate(float angle);
+	void scale(sf::Vector2f factor);
+	void scale(float factor); // scales both x and y by the same factor
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+private:
+	struct Sprite
+	{
+		bool isUpdateRequired;
+		sf::Sprite sprite;
+	};
+
+	const sf::Texture* m_texture;
+
+	std::function<bool(const sf::Sprite* a, const sf::Sprite* b)> m_orderFunction;
+	std::vector<std::size_t> m_orderIndices;
+
+	mutable std::vector<Sprite> m_sprites;
+	mutable bool m_isGlobalUpdateRequired;
+	mutable std::vector<sf::Vertex> m_vertices;
+
+	void draw(sf::RenderTarget& target, sf::RenderStates states) const;
+	void priv_testIsIndexValid(const std::size_t index) const;
+	void priv_updateAll() const;
+	void priv_updateRequired() const;
+	void priv_updateQuad(const std::size_t quadIndex, const sf::Sprite* sprite) const;
+};
+
+} // namespace selbaward
+#endif // SELBAWARD_SPRITEBATCH_HPP


### PR DESCRIPTION
add Sprite Batch, v1.

stores multiple sprites internally and creates a single vertex array from them when drawing. can avoid global updates in basic situations.

the stored sprites can be manipulated indirectly only via class methods. this allows only updating what is required.

if an order function exists (to sort pointer to sprites), it is used to order the sprites when updating; this forces global update to always be active. if no function exists, it will order them according to their storage and global updates are not required.

if a manual order (a vector of sprite indices) exists, this override the order function if it exists (but does not clear it). the manual order is used for the first part of the vector and any missing indices will follow in original order. if the manual order is cleared, the order function will be re-activated if it exists, otherwise it'll use the normal method.

setting the order function clears the manual order but clearing the order function does not clear the manual order.

neither setting nor clearing the order clears the order function (but if a manual order exists, it overrides the order function).

clearAllOrdering() is provided to clear both the order function and the manual order at once.

all standard SFML sprite methods are present but require a sprite index to be included (to identify which sprite to apply it to).

if "move", "rotate" and "scale" are used without a sprite index, it will be applied to all sprites.