### PR TITLE
Polygon - update to v1.4

### DIFF
--- a/src/SelbaWard/Polygon.hpp
+++ b/src/SelbaWard/Polygon.hpp
@@ -39,7 +39,7 @@
 namespace selbaward
 {
 
-// SW Polygon v1.3.0
+// SW Polygon v1.4.0
 class Polygon : public sf::Drawable, public sf::Transformable
 {
 public:
@@ -54,7 +54,13 @@ public:
 	};
 
 	Polygon();
+	Polygon(std::initializer_list<sf::Vector2f> list); // pass vertices' positions (sf::Vector2f) to the constructor (sets size automatically)
+	Polygon(const Polygon& polygon);
+	Polygon& operator=(const Polygon& polygon);
+
 	void update();
+
+	sf::Vertex& operator[] (std::size_t index); // direct access to the polygon's vertices (sf::Vertex) using the [] operator. no checks are performed. using with an invalid index results in undefined behaviour
 
 	void setColor(sf::Color color);
 	sf::Color getColor();
@@ -64,6 +70,9 @@ public:
 	void setMeshRefinementMethod(MeshRefinementMethod meshRefinementMethod);
 	MeshRefinementMethod getMeshRefinementMethod() const;
 
+	void setReverseDirection(bool reverseDirection);
+	bool getReverseDirection() const;
+
 	void reserveVertices(std::size_t numberOfVertices);
 
 	void setNumberOfVertices(std::size_t numberOfVertices);
@@ -71,6 +80,15 @@ public:
 
 	void setVertexPosition(std::size_t index, sf::Vector2f position);
 	sf::Vector2f getVertexPosition(std::size_t index) const;
+
+	void setVertexColor(std::size_t index, sf::Color color);
+	sf::Color getVertexColor(std::size_t index) const;
+
+	void setVertexTexCoords(std::size_t index, sf::Vector2f texCoords);
+	sf::Vector2f getVertexTexCoords(std::size_t index) const;
+
+	void setTexture(const sf::Texture& texture); // activate texture (ignored for wireframe)
+	void setTexture(); // de-activate/reset ("un-set") texture
 
 	void setTriangleLimit(std::size_t triangleLimit);
 	std::size_t getTriangleLimit() const;
@@ -81,15 +99,34 @@ public:
 	void setWireframeColor(sf::Color wireframeColor);
 	sf::Color getWireframeColor() const;
 
+	float getPerimeter() const;
+	float getArea() const;
+
+	bool isPointInside(sf::Vector2f point) const;
+
+	sf::FloatRect getLocalBounds() const;
+	sf::FloatRect getGlobalBounds() const;
+
+	sf::Vector2f getCentroid() const; // ignores holes - gives decent representation (averaged points of outer)
+	sf::Vector2f getCenterOfMass() const; // uses each point of each triangle, weighted by triangle area - represents actual "centre of mass"
+
 	void reverseVertices();
 
 	void importVertexPositions(const std::vector<sf::Vector2f>& position);
+	std::vector<sf::Vector2f> exportVertexPositions() const;
+	std::vector<sf::Vector2f> exportVertexPositionsOuterOnly() const;
+	std::vector<sf::Vector2f> exportVertexPositionsHoleOnly(std::size_t holeIndex) const;
 	std::vector<sf::Vector2f> exportTriangulatedPositions() const;
+	std::vector<sf::Vector2f> exportWireframePositions() const;
 
 	// holes must not overlap and must be specified in opposite direction to outer polygon
 	void addHoleStartIndex(std::size_t index);
 	void clearHoleStartIndices();
 	void setHoleStartIndices(const std::vector<std::size_t>& indices);
+	void setNumberOfHoles(std::size_t numberOfHoles);
+	void setHoleStartIndex(std::size_t holeIndex, std::size_t holeStartIndex);
+	std::size_t getNumberOfHoles() const;
+	std::size_t getHoleStartIndex(std::size_t holeIndex) const; // hole index indentifies the hole. returned value is the vertex index of the start of that hole. "number of vertices" is returned if there are no holes or hole does not exist.
 
 
 
@@ -99,6 +136,8 @@ public:
 
 private:
 	using TriangleIndices = std::array<std::size_t, 3u>;
+
+	const sf::Texture* m_texture;
 
 	std::vector<sf::Vertex> m_vertices;
 	std::vector<TriangleIndices> m_triangles;
@@ -115,18 +154,25 @@ private:
 
 	std::size_t m_triangleLimit;
 
-	const bool m_throwExceptions;
+	bool m_reverseDirection;
 
-	virtual void draw(sf::RenderTarget&, sf::RenderStates) const;
+	void draw(sf::RenderTarget&, sf::RenderStates) const override final;
 	void priv_update();
 	void priv_updateOutputVertices();
 	void priv_triangulate();
 	void priv_triangulateEarClip();
 	void priv_triangulateBasicEarClip();
 	bool priv_isValidVertexIndex(std::size_t vertexIndex) const;
+	bool priv_isValidHoleIndex(std::size_t holeIndex) const;
 	bool priv_testVertexIndex(std::size_t vertexIndex, const std::string& exceptionMessage) const;
+	bool priv_testHoleIndex(std::size_t holeIndex, const std::string& exceptionMessage) const;
 	void priv_buildWireframe();
 };
+
+inline sf::Vertex& Polygon::operator[] (const std::size_t index)
+{
+	return m_vertices[index];
+}
 
 } // namespace selbaward
 #endif // SELBAWARD_POLYGON_HPP


### PR DESCRIPTION
update Polygon to v1.4

adds:
- vertex color, and tex-coords
- bounds (local and global)
- texture (used by tex-coords if set, ignored if not set; always ignored by wireframe)
- ability to provide points in a reversed direction (i.e. clockwise for outer and anti-clockwise for holes - instead of anti-clockwise for outer and clockwise for holes)
- ability to get perimeter of polygon (length of all edges; include hole edges)
- ability to get area of polygon (after triangulation)
- ability to get if point is inside polygon (after triangulation)
- ability to get centroid (average of all outer's points; doesn't include hole vertices)
- ability to get centre of mass (actual centre of mass; based on triangles' areas)
- ability to get and set (existing) hole start indices/number of holes
- export vertex positions (the actual vertices forming the polygon boundary, in order)
- export vertex positions for only the outer boundary (does not include hole vertices)
- export vertex positions for only the given hole (vertices for the hole)
- export wireframe position (in pairs for each separate line)
- constructors (from other Polygon or initializer list of positions) and operator= (from other Polygon)
- operator[] to provide direct access to vertices (no validity checking). note that these are the vertices of the polygon "blueprint" - the thing you provide - not the actual vertices used to draw the shape.

also fixed:
- draw() signature: removed "virtual", added "override final" (just code-style update)
- now tests exception flag before throwing error in trangulation; also moved exception flag into cpp. note that this flag is always set to true.